### PR TITLE
Change LogAnalytics WorkspaceCapping DailyQuotaGB property to double

### DIFF
--- a/arm-estimator-tests/Bicep/LogAnalyticsTests.cs
+++ b/arm-estimator-tests/Bicep/LogAnalyticsTests.cs
@@ -55,8 +55,8 @@ namespace arm_estimator_tests.Bicep
             });
 
             Assert.That(output, Is.Not.Null);
-            Assert.That(output.TotalCost.OriginalValue, Is.EqualTo(574.25999999999999d));
-            Assert.That(output.TotalResourceCount, Is.EqualTo(2));
+            Assert.That(output.TotalCost.OriginalValue, Is.EqualTo(564.45310000000006d));
+            Assert.That(output.TotalResourceCount, Is.EqualTo(3));
         }
     }
 }

--- a/arm-estimator-tests/templates/bicep/usagePatterns/loganalytics.bicep
+++ b/arm-estimator-tests/templates/bicep/usagePatterns/loganalytics.bicep
@@ -26,3 +26,16 @@ resource la2 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
     }
   }
 }
+
+resource la3 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: 'usagepattern-la-cost-less-capping'
+  location: rgLocation
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    workspaceCapping: {
+      dailyQuotaGb: json('0.023')
+    }
+  }
+}

--- a/arm-estimator/Products/LogAnalytics/LogAnalyticsEstimationCalculation.cs
+++ b/arm-estimator/Products/LogAnalytics/LogAnalyticsEstimationCalculation.cs
@@ -21,7 +21,7 @@ internal class LogAnalyticsEstimationCalculation : BaseEstimation, IEstimationCa
         var items = GetItems();
         var summary = new TotalCostSummary();
 
-        int? dailyQuota = null;
+        double? dailyQuota = null;
         if (this.change.properties != null && this.change.properties.ContainsKey("workspaceCapping"))
         {
             var cappingProperties = ((JsonElement)this.change.properties["workspaceCapping"]).Deserialize<WorkspaceCapping>();

--- a/arm-estimator/Products/LogAnalytics/LogAnalyticsProperties.cs
+++ b/arm-estimator/Products/LogAnalytics/LogAnalyticsProperties.cs
@@ -9,5 +9,5 @@ internal class LogAnalyticsProperties
 internal class WorkspaceCapping
 {
     [JsonPropertyName("dailyQuotaGb")]
-    public int DailyQuotaGB { get; set; }
+    public double DailyQuotaGB { get; set; }
 }


### PR DESCRIPTION
Following the discussion from https://github.com/TheCloudTheory/arm-estimator/issues/180 this PR changes the `DailyQuotaGB` property to `double` type to support the floating-point GB quotas.